### PR TITLE
feat: add error handling for unknown path

### DIFF
--- a/cypress/e2e/main_spec.cy.js
+++ b/cypress/e2e/main_spec.cy.js
@@ -43,8 +43,7 @@ describe('Main Page', () => {
   describe('sad path', () => {
     beforeEach(() => {
       cy.intercept('https://rancid-tomatillos-api.onrender.com/api/v1/movies', {
-        statusCode: 500,
-        body: { movies: [] }
+        forceNetworkError: true
       }).as('getMoviesError')
 
       cy.visit('http://localhost:3000/')
@@ -54,6 +53,17 @@ describe('Main Page', () => {
       cy.wait('@getMoviesError')
       cy.on('window:alert', (alertText) => {
         expect(alertText).to.contains('Failed to fetch movies. Please try again later.')
+      })
+    })
+
+    it('displays an alert when a user navigates to an unknown route', () => {
+      cy.intercept('https://rancid-tomatillos-api.onrender.com/api/v1/movies/potatoes', {
+        forceNetworkError: true
+      }).as('getMoviesError')
+      
+      cy.wait('@getMoviesError')
+      cy.on('window:alert', (alertText) => {
+        expect(alertText).to.contains('404 - Page or Movie Not Found.')
       })
     })
   })

--- a/cypress/e2e/movie_details_spec.cy.js
+++ b/cypress/e2e/movie_details_spec.cy.js
@@ -15,11 +15,11 @@ describe('movie details spec', () => {
     cy.intercept("GET", 'https://rancid-tomatillos-api.onrender.com/api/v1/movies/155', {
       statusCode: 200,
       fixture: "movie_details_155"
-    })
+    }).as('getMovieDetails')
     cy.visit('http://localhost:3000/')
 
     cy.get(".movie-poster").first().click()
-    cy.wait
+    cy.wait('@getMovieDetails')
     cy.get('h2').contains('The Dark Knight')
     cy.get('.genre').contains("Drama")
     cy.get('.genre').contains("Action")
@@ -32,12 +32,12 @@ describe('movie details spec', () => {
     cy.intercept("GET", 'https://rancid-tomatillos-api.onrender.com/api/v1/movies/680', {
       statusCode: 200,
       fixture: "movie_details_680"
-    })
+    }).as('getMovieDetails')
     cy.visit('http://localhost:3000/')
 
 
     cy.get(".movie-poster").last().click()
-    cy.wait
+    cy.wait('@getMovieDetails')
     cy.get('h2').contains('Pulp Fiction')
     cy.get('.genre').contains("Thriller")
     cy.get('.genre').contains("Crime")

--- a/cypress/e2e/voting_spec.cy.js
+++ b/cypress/e2e/voting_spec.cy.js
@@ -74,8 +74,7 @@ describe('Voting', () => {
       cy.visit('http://localhost:3000/')
 
       cy.intercept('PATCH', 'https://rancid-tomatillos-api.onrender.com/api/v1/movies/155', {
-        statusCode: 500,
-        body: { movies: [] }
+        forceNetworkError: true
       }).as('patchMovieError')
     })
 

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -12,7 +12,8 @@ function App() {
   const [displayHomeBtn, setHomeBtn] = useState('hide-home-btn')
   const [displaySearchBar, setSearchBar] = useState('show-search-bar')
   const location = useLocation()
-
+  const [error, setError] = useState(null)
+  
 function changeHomeBtn() {
   setHomeBtn('show-home-btn')
   }
@@ -26,22 +27,27 @@ useEffect(() => {
   } 
 }, [location]);
 
-function displayPosters() {
+
+useEffect(() => {
   fetch("https://rancid-tomatillos-api.onrender.com/api/v1/movies")
-  .then(response => response.json())
+  .then(response => {
+    if (!response.ok) {
+      throw new Error('Failed to fetch movies')
+    }
+    return response.json()
+  })
   .then(data => {
     setPosters(data || [])
   })
   .catch(error => {
     console.error('Error fetching movies:', error)
-    setPosters([])
-    alert('Failed to fetch movies. Please try again later.')
+    setError('Failed to fetch movies. Please try again later.')
   })
-}
-
-useEffect(() => {
-  displayPosters()
   }, [])
+
+  if (error) {
+    return <div>{error}</div>
+  }
 
   function updateVoteCount(id, direction) {
     fetch(`https://rancid-tomatillos-api.onrender.com/api/v1/movies/${id}`, {
@@ -63,7 +69,6 @@ useEffect(() => {
       })
       .catch(error => {
         console.error('Error fetching movies:', error)
-        setPosters([])
         alert('Failed to fetch movies. Please try again later.')
       })
     } 
@@ -102,8 +107,7 @@ useEffect(() => {
           incrementVoteDown={incrementVoteDown} 
           incrementVoteUp={incrementVoteUp}
           changeHomeBtn={changeHomeBtn}/>}/>
-        <Route path='/:id' element={<MovieDetails
-          displayPosters={displayPosters} />}/>
+        <Route path='/:id' element={<MovieDetails/>} />
       </Routes>
     </main>
   );

--- a/src/MovieDetails/MovieDetails.js
+++ b/src/MovieDetails/MovieDetails.js
@@ -14,13 +14,16 @@ function MovieDetails() {
     })
     .catch(error => {
       console.error('Error fetching movie details:', error)
-      setMovie(null)
-      alert('Failed to fetch movie details. Please try again later.')
+      setMovie({error: true})
     })
-  }, [movieId])
+    }, [movieId])
 
   if (!movie) {
     return <p>Loading...</p>
+  }
+
+  if(movie.error) {
+    return <h2>404 - Page or Movie Not Found</h2>
   }
 
   return (


### PR DESCRIPTION
This PR adds error handling for a nonexistent route. I tried using a React routes method that I found to display a 404 error when navigating to a nonexistent route, but I kept getting errors when trying to implement. So I ultimately moved to movie details and tweaked that error message to run if either a movie id was not found or if a user navigates to an unknown path.