### PR TITLE
refactor home button tests and add navigation test

### DIFF
--- a/cypress/e2e/movie_details_spec.cy.js
+++ b/cypress/e2e/movie_details_spec.cy.js
@@ -54,20 +54,24 @@ describe('movie details spec', () => {
 
     cy.get(".movie-poster").first().click()
     cy.wait
-    cy.get('button').should('have.class', 'show-home-btn')
-    cy.get('.show-home-btn').find('img').should('have.attr', 'alt', 'Home button')  
+    cy.get('button').should('have.class', 'home-button')
+    cy.get('button').find('img').should('have.attr', 'alt', 'Home button')  
   })
 
-  it('displays an alert when the API call fails', () => {
+  it ('displays the intended content when navigating backward and forward', () => {
     cy.intercept("GET", 'https://rancid-tomatillos-api.onrender.com/api/v1/movies/155', {
-      forceNetworkError: true
+      statusCode: 200,
+      fixture: "movie_details_155"
     })
-    cy.visit('http://localhost:3000/')
 
+    cy.visit('http://localhost:3000/')
     cy.get(".movie-poster").first().click()
-    cy.wait
-    cy.on('window:alert', (alertText) => {
-      expect(alertText).to.equal('Failed to fetch movie details. Please try again later.')
-    })
+    cy.url().should('include', '/155')
+
+    cy.go('back')
+    cy.url().should('eq', 'http://localhost:3000/')
+
+    cy.go('forward')
+    cy.url().should('include', '/155')
   })
 })


### PR DESCRIPTION
This PR updates the Cypress tests for movie details after removing the show and hide button classes. It also adds testing for the forward and backward navigation. 